### PR TITLE
feat: tune parquet compression for faster duckdb reads

### DIFF
--- a/src/data/scripts/financing.parquet.py
+++ b/src/data/scripts/financing.parquet.py
@@ -230,7 +230,8 @@ def get_financing_data():
 
 def financing_to_parquet():
     df = get_financing_data()
-    df_to_parquet(df)
+    # Write parquet with a low compression level to favour fast reads in DuckDB
+    df_to_parquet(df, compression="zstd", compression_level=1)
 
 
 if __name__ == "__main__":

--- a/src/data/scripts/gender.parquet.py
+++ b/src/data/scripts/gender.parquet.py
@@ -62,7 +62,9 @@ def get_transform_gender():
 
 def gender_to_parquet():
     df = get_transform_gender()
-    df_to_parquet(df)
+    # Use a lightweight compression setting so DuckDB can read the files
+    # in the browser without incurring heavy decompression costs.
+    df_to_parquet(df, compression="zstd", compression_level=1)
 
 
 if __name__ == "__main__":

--- a/src/data/scripts/gni_table.parquet.py
+++ b/src/data/scripts/gni_table.parquet.py
@@ -58,7 +58,8 @@ def get_gni():
 
 def gni_to_parquet():
     df = get_gni()
-    df_to_parquet(df)
+    # Store with light compression to optimise browser-side DuckDB reads
+    df_to_parquet(df, compression="zstd", compression_level=1)
 
 
 if __name__ == "__main__":

--- a/src/data/scripts/recipients.parquet.py
+++ b/src/data/scripts/recipients.parquet.py
@@ -89,7 +89,8 @@ def combine_recipients():
 
 def recipients_to_parquet():
     df = combine_recipients()
-    df_to_parquet(df)
+    # Apply light compression so that DuckDB can load data quickly in the UI
+    df_to_parquet(df, compression="zstd", compression_level=1)
 
 
 if __name__ == "__main__":

--- a/src/data/scripts/sectors.parquet.py
+++ b/src/data/scripts/sectors.parquet.py
@@ -136,7 +136,8 @@ def merge_transform_sectors():
 
 def sectors_to_parquet():
     df = merge_transform_sectors()
-    df_to_parquet(df)
+    # Use a low compression level for quicker DuckDB queries in the browser
+    df_to_parquet(df, compression="zstd", compression_level=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow helper to customise compression used when emitting parquet data
- write generated datasets with lightweight zstd compression for quicker DuckDB loading

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6891c60197f88326ae4146894258c979