### PR TITLE
Feature/donors share recipients view

### DIFF
--- a/src/data/analysis_tools/transformations.py
+++ b/src/data/analysis_tools/transformations.py
@@ -273,7 +273,36 @@ def add_share_of_recipients_total_oda(df: pd.DataFrame) -> pd.DataFrame:
 
     merged = df.merge(total, on=["year", "recipient_code"], how="left")
 
-    merged["pct_of_total_oda"] = (
+    merged["pct_total_recipient"] = (
+        merged["value_usd_current"] / merged["total_oda"]
+    ).round(6)
+
+    merged = merged.drop(columns=["total_oda"])
+
+    return merged
+
+
+def add_share_of_donors_total_oda(df: pd.DataFrame) -> pd.DataFrame:
+    """Add column for each recipient's share of total ODA given by a donor.
+
+    Denominator is the donor's total ODA to Developing countries, per indicator.
+    """
+
+    developing_countries_code = RECIPIENT_GROUPS["Developing countries"]
+
+    total = (
+        df.loc[lambda d: d.recipient_code == developing_countries_code]
+        .groupby(["year", "donor_code"], dropna=False, observed=True)[
+            "value_usd_current"
+        ]
+        .sum()
+        .reset_index()
+        .rename(columns={"value_usd_current": "total_oda"})
+    )
+
+    merged = df.merge(total, on=["year", "donor_code"], how="left")
+
+    merged["pct_total_donor"] = (
         merged["value_usd_current"] / merged["total_oda"]
     ).round(6)
 

--- a/src/data/config.py
+++ b/src/data/config.py
@@ -33,7 +33,6 @@ OTHER_FINANCING_INDICATORS: dict = {
     "ONE.10.1010C": "Core ODA (ONE Definition)",
     "DAC1.10.1015": "Bilateral ODA",
     "DAC1.10.2000": "Multilateral ODA",
-    "DAC1.10.11026": "Debt relief",
     "DAC1.10.1600": "Debt relief",
     "DAC1.60.11030": "Private sector instruments",
     "DAC1.60.11040": "Private sector instruments",

--- a/src/data/config.py
+++ b/src/data/config.py
@@ -33,13 +33,12 @@ OTHER_FINANCING_INDICATORS: dict = {
     "ONE.10.1010C": "Core ODA (ONE Definition)",
     "DAC1.10.1015": "Bilateral ODA",
     "DAC1.10.2000": "Multilateral ODA",
+    "DAC1.10.11026": "Debt relief",
     "DAC1.10.1600": "Debt relief",
     "DAC1.60.11030": "Private sector instruments",
     "DAC1.60.11040": "Private sector instruments",
     "DAC1.60.11023": "Private sector instruments - institutional approach",
-    "DAC1.60.11041": "Private sector instruments - institutional approach",
     "DAC1.60.11024": "Private sector instruments - instrument approach",
-    "DAC1.60.11042": "Private sector instruments - instrument approach",
 }
 
 FINANCING_INDICATORS: dict = OTHER_FINANCING_INDICATORS | IN_DONOR_FINANCING_INDICATORS

--- a/src/data/scripts/recipients_view.parquet.py
+++ b/src/data/scripts/recipients_view.parquet.py
@@ -12,6 +12,7 @@ from src.data.analysis_tools.transformations import (
     add_recipient_groupings,
     add_recipient_names,
     add_share_of_recipients_total_oda,
+    add_share_of_donors_total_oda,
 )
 from src.data.config import PATHS, RECIPIENTS_INDICATORS, BASE_TIME, logger
 
@@ -116,8 +117,9 @@ def combined_recipients():
         ),
     )
 
-    # Add share of total ODA
+    # Add share of total ODA from recipient's and donor's perspective
     recipients = add_share_of_recipients_total_oda(recipients)
+    recipients = add_share_of_donors_total_oda(recipients)
 
     # Convert values to units (integers) for better compression
     # NOTE: Frontend queries must divide value_* columns by 1e6 to get millions

--- a/src/js/recipientQueries.js
+++ b/src/js/recipientQueries.js
@@ -65,13 +65,23 @@ export function recipientsQueries(
         donor: row.donor,
         recipient: row.recipient,
         indicator: row.indicator,
-        value: row.pct_of_total_oda * 100,
+        value: row.pct_total_recipient * 100,
         unit: "% of total ODA",
         source: "OECD DAC2A"
     })), timeRange);
 
     // Return raw rows for table transformation
-    return {absolute, relative, rawData: rows};
+    const relativeDonor = fillMissingYearIndicators(rows.map((row) => ({
+        year: row.year,
+        donor: row.donor,
+        recipient: row.recipient,
+        indicator: row.indicator,
+        value: row.pct_total_donor != null ? row.pct_total_donor * 100 : null,
+        unit: "% of total ODA provided",
+        source: "OECD DAC2A"
+    })), timeRange);
+
+    return {absolute, relative, relativeDonor, rawData: rows};
 }
 
 // Separate table transformation so unit changes don't trigger base query
@@ -83,10 +93,14 @@ export function transformTableData(rows, unit, currency, prices) {
         indicator: row.indicator,
         value: unit === "value"
             ? row.value
-            : row.pct_of_total_oda * 100,
+            : unit === "pct_total_recipient"
+                ? (row.pct_total_recipient != null ? row.pct_total_recipient * 100 : null)
+                : (row.pct_total_donor != null ? row.pct_total_donor * 100 : null),
         unit: unit === "value"
             ? `${currency} ${prices} million`
-            : "% of bilateral + imputed multilateral ODA",
+            : unit === "pct_total_recipient"
+                ? "% of received aid"
+                : "% of provided aid",
         source: "OECD DAC2A"
     }));
 }
@@ -160,7 +174,8 @@ function executeRecipientsSeries(
             recipient: row.recipient_name,
             indicator: row.indicator_name,
             value: convertUnitsToMillions(row[valueColumn]),
-            pct_of_total_oda: row.pct_of_total_oda ?? null
+            pct_total_recipient: row.pct_total_recipient ?? null,
+            pct_total_donor: row.pct_total_donor ?? null
         }))
         .sort((a, b) => {
             if (a.year !== b.year) return a.year - b.year;

--- a/src/js/sparkBarTable.js
+++ b/src/js/sparkBarTable.js
@@ -38,7 +38,8 @@ export function sparkbarTable(data, mode, {breakdown, currency = null, scale = n
         maxValues,
         colorColumn = null,
         getColorForType = () => customPalette.lightGrey,
-        colorPalette = [];
+        colorPalette = [],
+        sortPalette = null;
 
     if (mode === "financing") {
 
@@ -60,7 +61,7 @@ export function sparkbarTable(data, mode, {breakdown, currency = null, scale = n
 
     } else {
 
-        let groupVar, contextColumns, sortPalette;
+        let groupVar, contextColumns;
 
         if (mode === "recipients") {
             groupVar = "Indicator";
@@ -144,8 +145,12 @@ export function sparkbarTable(data, mode, {breakdown, currency = null, scale = n
                                 cellFmt
                             )(rowValue);
                         } else {
+                            const paletteIndex = sortPalette
+                                ? sortPalette.domain.indexOf(column)
+                                : -1;
+                            const effectiveIndex = paletteIndex !== -1 ? paletteIndex : index % colorPalette.length;
                             return sparkbar(
-                                colorPalette[index % colorPalette.length],
+                                colorPalette[effectiveIndex],
                                 "left",
                                 minValues,
                                 maxValues,

--- a/src/recipients.md
+++ b/src/recipients.md
@@ -60,6 +60,7 @@ function App() {
   const [prices, setPrices] = React.useState("constant")
   const [timeRange, setTimeRange] = React.useState([timeRangeOptions.end - 20, timeRangeOptions.end])
   const [unit, setUnit] = React.useState("value")
+  const [tableView, setTableView] = React.useState("disaggregated")
 
   const unitOptions = React.useMemo(() => [
     {label: getCurrencyLabel(currency, {currencyLong: true, currencyOnly: true}), value: "value"},
@@ -86,6 +87,20 @@ function App() {
     [data?.rawData, unit, currency, prices]
   )
 
+  const displayTableData = React.useMemo(() => {
+    if (tableView === "total" && indicator.length > 1) {
+      const byYear = new Map()
+      for (const row of tableData) {
+        if (!byYear.has(row.year)) {
+          byYear.set(row.year, { ...row, indicator: "Bilateral + imputed multilateral ODA", value: 0 })
+        }
+        byYear.get(row.year).value += row.value ?? 0
+      }
+      return [...byYear.values()]
+    }
+    return tableData
+  }, [tableData, tableView, indicator])
+
   const donorName = formatString(getNameByCode(donorMapping, donor) ?? "")
   const recipientName = getNameByCode(recipientMapping, recipient) ?? ""
     const currencyLabel = getCurrencyLabel(currency, {currencyOnly: true, currencyLong: true})
@@ -101,7 +116,7 @@ function App() {
 
   const relativeIndicatorSubtitle = React.useMemo(() => {
     if (indicator.length > 1) {
-      return `<span style="color:${customPalette.bilateral}; font-weight:600">Bilateral</span> and <span style="color:${customPalette.multilateral}; font-weight:600">imputed multilateral</span> as a share of the total`
+      return `<span style="color:${customPalette.bilateral}; font-weight:600">Bilateral</span> and <span style="color:${customPalette.multilateral}; font-weight:600">imputed multilateral</span> as a share of aid received by ${recipientName}`
     }
     const name = getNameByCode(indicatorMapping, indicator) ?? ""
     return `${name} as a share of the total`
@@ -117,9 +132,18 @@ function App() {
     [relativeData]
   )
 
+  const tableSubtitle = React.useMemo(() => {
+    if (tableView === "total" && indicator.length > 1) {
+      return unit === "value"
+        ? `<span style="color:${customPalette.total}; font-weight:600">Bilateral + imputed multilateral</span> ODA`
+        : `<span style="color:${customPalette.total}; font-weight:600">Bilateral + imputed multilateral</span> as a share of aid received by ${recipientName}`
+    }
+    return unit === "value" ? indicatorSubtitle : relativeIndicatorSubtitle
+  }, [tableView, indicator, unit, indicatorSubtitle, relativeIndicatorSubtitle, recipientName])
+
   const tableFn = React.useCallback(
-    () => sparkbarTable(tableData, "recipients", { currency, scale: absoluteScale, unit }),
-    [tableData, currency, absoluteScale, unit]
+    () => sparkbarTable(displayTableData, "recipients", { currency, scale: absoluteScale, unit }),
+    [displayTableData, currency, absoluteScale, unit]
   )
 
   const columnFilename = formatString(`${donorName} ${recipientName}`, {fileMode: true})
@@ -224,20 +248,33 @@ function App() {
             
             <ONEVisual
               title={`ODA to ${recipientName} from ${donorName}`}
-              subtitle={indicatorSubtitle}
+              subtitle={tableSubtitle}
               subtitleIsHTML={true}
               source="OECD DAC2A table."
               controls={
+                <>
                   <DropdownMenuMini label="Unit" options={unitOptions} value={unit} onChange={setUnit} search={false} />
+                  {indicator.length > 1 && (
+                    <ToggleSwitchMini
+                      label="View"
+                      value={tableView}
+                      options={[
+                        {label: "Disaggregated", value: "disaggregated"},
+                        {label: "Total", value: "total"}
+                      ]}
+                      onChange={setTableView}
+                    />
+                  )}
+                </>
               }
               note={tableNote}
-              empty={tableData.length === 0}
+              empty={displayTableData.length === 0}
               emptyMessage="No data available"
               fileName={tableFilename}
-              data={tableData}
+              data={displayTableData}
               dataDownload={true}
             >
-              <AutoTable data={tableData} tableFn={tableFn} />
+              <AutoTable data={displayTableData} tableFn={tableFn} />
             </ONEVisual>
         </>
       )}

--- a/src/recipients.md
+++ b/src/recipients.md
@@ -61,10 +61,12 @@ function App() {
   const [timeRange, setTimeRange] = React.useState([timeRangeOptions.end - 20, timeRangeOptions.end])
   const [unit, setUnit] = React.useState("value")
   const [tableView, setTableView] = React.useState("disaggregated")
+  const [relativePerspective, setRelativePerspective] = React.useState("recipient")
 
   const unitOptions = React.useMemo(() => [
     {label: getCurrencyLabel(currency, {currencyLong: true, currencyOnly: true}), value: "value"},
-    {label: "% of Bilateral + Imputed multilateral ODA", value: "pct_total"},
+    {label: "% of received aid", value: "pct_total_recipient"},
+    {label: "% of provided aid", value: "pct_total_donor"},
   ], [currency])
 
   const data = React.useMemo(
@@ -75,7 +77,9 @@ function App() {
   )
 
   const absoluteData = data?.absolute ?? []
-  const relativeData = data?.relative ?? []
+  const relativeData = relativePerspective === "recipient"
+    ? (data?.relative ?? [])
+    : (data?.relativeDonor ?? [])
 
   const absoluteScale = React.useMemo(
     () => resolveScale(absoluteData.map(d => d.value), SCALE),
@@ -115,12 +119,15 @@ function App() {
   }, [indicator])
 
   const relativeIndicatorSubtitle = React.useMemo(() => {
+    const shareText = relativePerspective === "recipient"
+      ? `as a share of aid received by ${recipientName}`
+      : `as a share of aid provided by ${donorName}`
     if (indicator.length > 1) {
-      return `<span style="color:${customPalette.bilateral}; font-weight:600">Bilateral</span> and <span style="color:${customPalette.multilateral}; font-weight:600">imputed multilateral</span> as a share of aid received by ${recipientName}`
+      return `<span style="color:${customPalette.bilateral}; font-weight:600">Bilateral</span> and <span style="color:${customPalette.multilateral}; font-weight:600">imputed multilateral</span> ${shareText}`
     }
     const name = getNameByCode(indicatorMapping, indicator) ?? ""
-    return `${name} as a share of the total`
-  }, [indicator])
+    return `${name} ${shareText}`
+  }, [indicator, relativePerspective, recipientName, donorName])
 
   const columnChartFn = React.useCallback(
     (width) => columnChart(absoluteData, currency, "recipients", width, { scale: absoluteScale }),
@@ -133,13 +140,23 @@ function App() {
   )
 
   const tableSubtitle = React.useMemo(() => {
-    if (tableView === "total" && indicator.length > 1) {
-      return unit === "value"
+    if (unit === "value") {
+      return tableView === "total" && indicator.length > 1
         ? `<span style="color:${customPalette.total}; font-weight:600">Bilateral + imputed multilateral</span> ODA`
-        : `<span style="color:${customPalette.total}; font-weight:600">Bilateral + imputed multilateral</span> as a share of aid received by ${recipientName}`
+        : indicatorSubtitle
     }
-    return unit === "value" ? indicatorSubtitle : relativeIndicatorSubtitle
-  }, [tableView, indicator, unit, indicatorSubtitle, relativeIndicatorSubtitle, recipientName])
+    const shareText = unit === "pct_total_recipient"
+      ? `as a share of aid received by ${recipientName}`
+      : `as a share of aid provided by ${donorName}`
+    if (tableView === "total" && indicator.length > 1) {
+      return `<span style="color:${customPalette.total}; font-weight:600">Bilateral + imputed multilateral</span> ${shareText}`
+    }
+    if (indicator.length > 1) {
+      return `<span style="color:${customPalette.bilateral}; font-weight:600">Bilateral</span> and <span style="color:${customPalette.multilateral}; font-weight:600">imputed multilateral</span> ${shareText}`
+    }
+    const name = getNameByCode(indicatorMapping, indicator) ?? ""
+    return `${name} ${shareText}`
+  }, [tableView, indicator, unit, indicatorSubtitle, recipientName, donorName])
 
   const tableFn = React.useCallback(
     () => sparkbarTable(displayTableData, "recipients", { currency, scale: absoluteScale, unit }),
@@ -152,7 +169,9 @@ function App() {
 
   const tableNote = unit === "value"
     ? `ODA values in ${pricesNote} ${currencyLabel}.`
-    : `ODA values as a share of all aid from bilateral donors to ${recipientName}.`
+    : unit === "pct_total_recipient"
+      ? `ODA values as a share of all aid from bilateral donors to ${recipientName}.`
+      : `ODA values as a share of all aid provided by ${donorName} to developing countries.`
 
   return (
       <div className="mx-auto space-y-12 px-4 py-10 sm:px-8 sm:py-16 lg:px-12 lg:py-20">
@@ -234,7 +253,21 @@ function App() {
                 subtitle={relativeIndicatorSubtitle}
                 subtitleIsHTML={true}
                 source="OECD DAC2A table."
-                note={`ODA values as a share of all aid from bilateral donors to ${recipientName}.`}
+                controls={
+                  <ToggleSwitchMini
+                    label="Perspective"
+                    value={relativePerspective}
+                    options={[
+                      {label: "Received", value: "recipient"},
+                      {label: "Provided", value: "donor"}
+                    ]}
+                    onChange={setRelativePerspective}
+                  />
+                }
+                note={relativePerspective === "recipient"
+                  ? `ODA values as a share of all aid from bilateral donors to ${recipientName}.`
+                  : `ODA values as a share of all aid provided by ${donorName} to developing countries.`
+                }
                 empty={relativeData.length === 0}
                 emptyMessage="No data available"
                 fileName={areaFilename}


### PR DESCRIPTION
This PR creates a series in `recipients_view.parquet` with aid to a particular recipient as a share of all aid provided by a particular donor. 

It also adds a toggle input to the relative chart in the recipients view so that users can switch between the providers and recipients perspective.