### PR TITLE
Feature/overview consistent naming

### DIFF
--- a/src/data/topic_page/overview.py
+++ b/src/data/topic_page/overview.py
@@ -46,7 +46,14 @@ def total_aid_key_number() -> None:
         .filter(["name", "first_line", "value", "second_line", "pct_change", "centre"])
     )
 
-    data.to_csv(PATHS.TOPIC_PAGE / "sm_total_oda_csv", index=False)
+    data.rename(columns={
+        "name": "Donor",
+        "first_line": "Period",
+        "value": "Total ODA",
+        "second_line": "Subtitle",
+        "pct_change": "Annual change",
+        "centre": "Centre",
+    }).to_csv(PATHS.TOPIC_PAGE / "sm_total_oda_csv", index=False)
     logger.info(f"Saved chart version of sm_total_oda.csv for {LATEST_YEAR_AGG}")
 
     kn = {
@@ -82,7 +89,13 @@ def aid_gni_key_number() -> None:
     )
 
     # Save chart version
-    data.to_csv(PATHS.TOPIC_PAGE / "oda_gni_sm.csv", index=False)
+    data.rename(columns={
+        "first_line": "Period",
+        "oda_gni": "ODA/GNI",
+        "second_line": "Subtitle",
+        "distance": "Gap to 0.7%",
+        "centre": "Centre",
+    }).to_csv(PATHS.TOPIC_PAGE / "oda_gni_sm.csv", index=False)
     logger.info(f"Saved chart version of oda_gni_sm.csv for {LATEST_YEAR_AGG}")
 
     # Save dynamic text version
@@ -117,26 +130,25 @@ def aid_to_africa_ts() -> None:
 
     data = (
         data.assign(
-            share=lambda d: format_number(
-                d["Africa, Total"] / d["Developing Countries, Total"],
-                as_percentage=True,
-                decimals=1,
+            share=lambda d: (d["Africa, Total"] / d["Developing Countries, Total"]).apply(
+                lambda x: f'"{x:.1%}"' if pd.notna(x) else ""
             )
         )
         .rename(columns={"Africa, Total": "value"})
         .filter(["year", "donor_name", "value", "share"])
         .pipe(add_change, as_formatted_str=True, grouper="donor_name")
-        .assign(
-            value=lambda d: format_number(d.value * 1e6, as_billions=True, decimals=1),
-            name=lambda d: d.donor_name,
-        )
-        .rename(columns={"value": "Aid to Africa", "share": "Share of total ODA"})
+        .assign(value=lambda d: format_number(d.value * 1e6, as_billions=True, decimals=1))
+        .rename(columns={
+            "year": "Year",
+            "donor_name": "Donor",
+            "value": "Aid to Africa",
+            "share": "Share of total ODA",
+            "pct_change": "Annual change",
+        })
     )
-    # chart version
     data.to_csv(f"{PATHS.TOPIC_PAGE}/aid_to_africa_ts.csv", index=False)
     logger.info(f"Saved chart version of aid_to_africa_ts.csv for {LATEST_YEAR_AGG}")
 
-    # Dynamic text version
     kn = {
         "aid_to_africa": f"{data['Aid to Africa'].values[-1]} billion",
         "aid_to_africa_share": f"{data['Share of total ODA'].values[-1]}",
@@ -186,20 +198,26 @@ def aid_to_incomes_latest():
         )
         .filter(["name", "year", "recipient", "value", "share", "label"], axis=1)
     )
-    # chart version
-    data.to_csv(f"{PATHS.TOPIC_PAGE}/aid_to_income_latest.csv", index=False)
-    logger.debug("Saved chart version of aid_to_income_latest.csv")
-
-    # Dynamic text version
+    # Dynamic text version (must run before rename to preserve internal column names)
     income_dict = df_to_key_number(
         data,
         indicator_name="aid_to_incomes",
         id_column="recipient",
         value_columns=["value", "share"],
     )
-
     update_key_number(f"{PATHS.TOPIC_PAGE}/oda_key_numbers.json", income_dict)
     logger.debug("Updated dynamic text ODA topic page oda_key_numbers.json")
+
+    # Chart version
+    data.rename(columns={
+        "name": "Donor",
+        "year": "Year",
+        "recipient": "Recipient",
+        "value": "ODA",
+        "share": "Share of total ODA",
+        "label": "Label",
+    }).to_csv(f"{PATHS.TOPIC_PAGE}/aid_to_income_latest.csv", index=False)
+    logger.debug("Saved chart version of aid_to_income_latest.csv")
 
 
 def aid_to_sectors_ts() -> None:
@@ -211,7 +229,7 @@ def aid_to_sectors_ts() -> None:
             broad=True,
             base_year=LATEST_YEAR_DETAIL,
         )
-        .assign(recipient="All Developing Countries", name="DAC Countries, Total")
+        .assign(recipient="All Developing Countries", name="DAC countries")
         .groupby(
             ["year", "name", "recipient", "sub_sector"], dropna=False, observed=True
         )["value"]
@@ -219,18 +237,23 @@ def aid_to_sectors_ts() -> None:
         .reset_index(drop=False)
     )
 
-    data["share"] = format_number(
+    data["share"] = (
         data["value"]
-        / data.groupby(["year", "name", "recipient"])["value"].transform("sum"),
-        decimals=1,
-        as_percentage=True,
-    )
+        / data.groupby(["year", "name", "recipient"])["value"].transform("sum")
+    ).apply(lambda x: f'"{x:.1%}"' if pd.notna(x) else "")
 
     data["value"] = format_number(data["value"] * 1e6, as_billions=True, decimals=1)
 
     # Health
     data_health = data.loc[lambda d: d.sub_sector.isin(["Health"])].rename(
-        columns={"value": "Total aid to health", "share": "Share of total ODA"}
+        columns={
+            "year": "Year",
+            "name": "Donor",
+            "recipient": "Recipient",
+            "sub_sector": "Sector",
+            "value": "Total aid to health",
+            "share": "Share of total ODA",
+        }
     )
 
     # chart version
@@ -246,7 +269,14 @@ def aid_to_sectors_ts() -> None:
 
     # Humanitarian
     data_humanitarian = data.loc[lambda d: d.sub_sector.isin(["Humanitarian"])].rename(
-        columns={"value": "Total Humanitarian Aid", "share": "Share of total ODA"}
+        columns={
+            "year": "Year",
+            "name": "Donor",
+            "recipient": "Recipient",
+            "sub_sector": "Sector",
+            "value": "Total Humanitarian Aid",
+            "share": "Share of total ODA",
+        }
     )
     # chart version
     data_humanitarian.to_csv(
@@ -275,7 +305,7 @@ KEY_SECTORS: list[str] = [
 def key_sector_shares() -> None:
     """Generate sector shares of total bilateral + imputed multilateral ODA, by donor and year."""
     donor_names: dict[int, str] = provider_groupings()["dac_countries"] | {
-        20001: "DAC Countries, Total"
+        20001: "DAC countries"
     }
 
     raw = total_sectors(
@@ -320,10 +350,11 @@ def key_sector_shares() -> None:
         .reset_index()
         .filter(["year", "name"] + KEY_SECTORS, axis=1)
         # DAC total first within each year, then donors alphabetically
-        .assign(_sort=lambda d: d["name"].where(d["name"] != "DAC Countries, Total", ""))
+        .assign(_sort=lambda d: d["name"].where(d["name"] != "DAC countries", ""))
         .sort_values(["year", "_sort"])
         .drop(columns="_sort")
         .reset_index(drop=True)
+        .rename(columns={"year": "Year", "name": "Donor"})
     )
 
     result.to_csv(PATHS.TOPIC_PAGE / "key_sector_shares.csv", index=False)

--- a/topic_page/aid_to_africa_ts.csv
+++ b/topic_page/aid_to_africa_ts.csv
@@ -1,16 +1,16 @@
-year,donor_name,Aid to Africa,Share of total ODA,pct_change,name
-2010,"DAC Countries, Total",55.3,36.7%,,"DAC Countries, Total"
-2011,"DAC Countries, Total",55.4,37.0%,0.1%,"DAC Countries, Total"
-2012,"DAC Countries, Total",54.3,38.2%,-1.9%,"DAC Countries, Total"
-2013,"DAC Countries, Total",53.8,36.1%,-0.9%,"DAC Countries, Total"
-2014,"DAC Countries, Total",54.2,35.2%,0.7%,"DAC Countries, Total"
-2015,"DAC Countries, Total",53.4,33.1%,-1.4%,"DAC Countries, Total"
-2016,"DAC Countries, Total",57.6,31.9%,7.9%,"DAC Countries, Total"
-2017,"DAC Countries, Total",60.2,33.5%,4.5%,"DAC Countries, Total"
-2018,"DAC Countries, Total",59.8,34.1%,-0.7%,"DAC Countries, Total"
-2019,"DAC Countries, Total",58.9,34.4%,-1.6%,"DAC Countries, Total"
-2020,"DAC Countries, Total",64.9,35.2%,10.3%,"DAC Countries, Total"
-2021,"DAC Countries, Total",70.4,35.5%,8.4%,"DAC Countries, Total"
-2022,"DAC Countries, Total",60.7,25.6%,-13.8%,"DAC Countries, Total"
-2023,"DAC Countries, Total",64.5,26.7%,6.3%,"DAC Countries, Total"
-2024,"DAC Countries, Total",59.0,26.8%,-8.6%,"DAC Countries, Total"
+Year,Donor,Aid to Africa,Share of total ODA,Annual change
+2010,"DAC Countries, Total",55.3,"""36.7%""",
+2011,"DAC Countries, Total",55.4,"""37.0%""",0.1%
+2012,"DAC Countries, Total",54.3,"""38.2%""",-1.9%
+2013,"DAC Countries, Total",53.8,"""36.1%""",-0.9%
+2014,"DAC Countries, Total",54.2,"""35.2%""",0.7%
+2015,"DAC Countries, Total",53.4,"""33.1%""",-1.4%
+2016,"DAC Countries, Total",57.6,"""31.9%""",7.9%
+2017,"DAC Countries, Total",60.2,"""33.5%""",4.5%
+2018,"DAC Countries, Total",59.8,"""34.1%""",-0.7%
+2019,"DAC Countries, Total",58.9,"""34.4%""",-1.6%
+2020,"DAC Countries, Total",64.9,"""35.2%""",10.3%
+2021,"DAC Countries, Total",70.4,"""35.5%""",8.4%
+2022,"DAC Countries, Total",60.7,"""25.6%""",-13.8%
+2023,"DAC Countries, Total",64.5,"""26.7%""",6.3%
+2024,"DAC Countries, Total",59.0,"""26.8%""",-8.6%

--- a/topic_page/aid_to_health_ts.csv
+++ b/topic_page/aid_to_health_ts.csv
@@ -1,16 +1,16 @@
-year,name,recipient,sub_sector,Total aid to health,Share of total ODA
-2010,"DAC Countries, Total",All Developing Countries,Health,14.5,9.4%
-2011,"DAC Countries, Total",All Developing Countries,Health,15.4,10.0%
-2012,"DAC Countries, Total",All Developing Countries,Health,21.7,12.1%
-2013,"DAC Countries, Total",All Developing Countries,Health,23.9,12.2%
-2014,"DAC Countries, Total",All Developing Countries,Health,23.9,12.0%
-2015,"DAC Countries, Total",All Developing Countries,Health,21.3,10.3%
-2016,"DAC Countries, Total",All Developing Countries,Health,23.9,10.4%
-2017,"DAC Countries, Total",All Developing Countries,Health,24.9,10.8%
-2018,"DAC Countries, Total",All Developing Countries,Health,24.4,10.7%
-2019,"DAC Countries, Total",All Developing Countries,Health,21.8,9.6%
-2020,"DAC Countries, Total",All Developing Countries,Health,28.3,11.7%
-2021,"DAC Countries, Total",All Developing Countries,Health,37.5,14.4%
-2022,"DAC Countries, Total",All Developing Countries,Health,37.0,12.5%
-2023,"DAC Countries, Total",All Developing Countries,Health,24.9,7.9%
-2024,"DAC Countries, Total",All Developing Countries,Health,27.6,9.6%
+Year,Donor,Recipient,Sector,Total aid to health,Share of total ODA
+2010,DAC countries,All Developing Countries,Health,14.5,"""9.4%"""
+2011,DAC countries,All Developing Countries,Health,15.4,"""10.0%"""
+2012,DAC countries,All Developing Countries,Health,21.7,"""12.1%"""
+2013,DAC countries,All Developing Countries,Health,23.9,"""12.2%"""
+2014,DAC countries,All Developing Countries,Health,23.9,"""12.0%"""
+2015,DAC countries,All Developing Countries,Health,21.3,"""10.3%"""
+2016,DAC countries,All Developing Countries,Health,23.9,"""10.4%"""
+2017,DAC countries,All Developing Countries,Health,24.9,"""10.8%"""
+2018,DAC countries,All Developing Countries,Health,24.4,"""10.7%"""
+2019,DAC countries,All Developing Countries,Health,21.8,"""9.6%"""
+2020,DAC countries,All Developing Countries,Health,28.3,"""11.7%"""
+2021,DAC countries,All Developing Countries,Health,37.5,"""14.4%"""
+2022,DAC countries,All Developing Countries,Health,37.0,"""12.5%"""
+2023,DAC countries,All Developing Countries,Health,24.9,"""7.9%"""
+2024,DAC countries,All Developing Countries,Health,27.6,"""9.6%"""

--- a/topic_page/aid_to_humanitarian_ts.csv
+++ b/topic_page/aid_to_humanitarian_ts.csv
@@ -1,16 +1,16 @@
-year,name,recipient,sub_sector,Total Humanitarian Aid,Share of total ODA
-2010,"DAC Countries, Total",All Developing Countries,Humanitarian,11.4,7.4%
-2011,"DAC Countries, Total",All Developing Countries,Humanitarian,10.8,7.0%
-2012,"DAC Countries, Total",All Developing Countries,Humanitarian,12.2,6.8%
-2013,"DAC Countries, Total",All Developing Countries,Humanitarian,14.9,7.6%
-2014,"DAC Countries, Total",All Developing Countries,Humanitarian,18.0,9.0%
-2015,"DAC Countries, Total",All Developing Countries,Humanitarian,19.4,9.4%
-2016,"DAC Countries, Total",All Developing Countries,Humanitarian,21.2,9.2%
-2017,"DAC Countries, Total",All Developing Countries,Humanitarian,23.7,10.3%
-2018,"DAC Countries, Total",All Developing Countries,Humanitarian,23.1,10.1%
-2019,"DAC Countries, Total",All Developing Countries,Humanitarian,24.7,10.9%
-2020,"DAC Countries, Total",All Developing Countries,Humanitarian,24.9,10.3%
-2021,"DAC Countries, Total",All Developing Countries,Humanitarian,29.2,11.2%
-2022,"DAC Countries, Total",All Developing Countries,Humanitarian,31.9,10.8%
-2023,"DAC Countries, Total",All Developing Countries,Humanitarian,33.3,10.6%
-2024,"DAC Countries, Total",All Developing Countries,Humanitarian,29.5,10.3%
+Year,Donor,Recipient,Sector,Total Humanitarian Aid,Share of total ODA
+2010,DAC countries,All Developing Countries,Humanitarian,11.4,"""7.4%"""
+2011,DAC countries,All Developing Countries,Humanitarian,10.8,"""7.0%"""
+2012,DAC countries,All Developing Countries,Humanitarian,12.2,"""6.8%"""
+2013,DAC countries,All Developing Countries,Humanitarian,14.9,"""7.6%"""
+2014,DAC countries,All Developing Countries,Humanitarian,18.0,"""9.0%"""
+2015,DAC countries,All Developing Countries,Humanitarian,19.4,"""9.4%"""
+2016,DAC countries,All Developing Countries,Humanitarian,21.2,"""9.2%"""
+2017,DAC countries,All Developing Countries,Humanitarian,23.7,"""10.3%"""
+2018,DAC countries,All Developing Countries,Humanitarian,23.1,"""10.1%"""
+2019,DAC countries,All Developing Countries,Humanitarian,24.7,"""10.9%"""
+2020,DAC countries,All Developing Countries,Humanitarian,24.9,"""10.3%"""
+2021,DAC countries,All Developing Countries,Humanitarian,29.2,"""11.2%"""
+2022,DAC countries,All Developing Countries,Humanitarian,31.9,"""10.8%"""
+2023,DAC countries,All Developing Countries,Humanitarian,33.3,"""10.6%"""
+2024,DAC countries,All Developing Countries,Humanitarian,29.5,"""10.3%"""

--- a/topic_page/aid_to_income_latest.csv
+++ b/topic_page/aid_to_income_latest.csv
@@ -1,4 +1,4 @@
-name,year,recipient,value,share,label
+Donor,Year,Recipient,ODA,Share of total ODA,Label
 "DAC Countries, Total",2024,High income,0.8,0.4%,High income: 0.4%
 "DAC Countries, Total",2024,Low income,27.0,12.9%,Low income: 12.9%
 "DAC Countries, Total",2024,Lower-middle income,48.0,23.0%,Lower-middle income: 23.0%

--- a/topic_page/key_sector_shares.csv
+++ b/topic_page/key_sector_shares.csv
@@ -1,5 +1,5 @@
-year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment Protection
-2010,"DAC Countries, Total",0.0737,0.0655,0.094,0.0264,0.0314
+Year,Donor,Humanitarian,Education,Health,Refugees in Donor Countries,Environment Protection
+2010,DAC countries,0.0737,0.0655,0.094,0.0264,0.0314
 2010,Australia,0.0851,0.0685,0.0871,0.0014,0.0262
 2010,Austria,0.0197,0.1068,0.0081,0.0297,0.007
 2010,Belgium,0.0451,0.071,0.0527,0.0309,0.0028
@@ -24,7 +24,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2010,Switzerland,0.1101,0.0207,0.0248,0.1579,0.0201
 2010,United Kingdom,0.0422,0.0555,0.0898,0.0013,0.066
 2010,United States,0.156,0.0333,0.212,0.0287,0.0122
-2011,"DAC Countries, Total",0.0699,0.062,0.0998,0.031,0.023
+2011,DAC countries,0.0699,0.062,0.0998,0.031,0.023
 2011,Australia,0.0862,0.0898,0.0977,0.0,0.0208
 2011,Austria,0.0127,0.1198,0.0134,0.0377,0.007
 2011,Belgium,0.0544,0.0714,0.0555,0.0414,0.0028
@@ -51,7 +51,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2011,Switzerland,0.0969,0.028,0.0255,0.1732,0.0314
 2011,United Kingdom,0.0479,0.0737,0.1073,0.0022,0.014
 2011,United States,0.1323,0.0274,0.2262,0.0259,0.0137
-2012,"DAC Countries, Total",0.068,0.0632,0.1209,0.0271,0.0275
+2012,DAC countries,0.068,0.0632,0.1209,0.0271,0.0275
 2012,Australia,0.0639,0.1005,0.1147,0.0252,0.0242
 2012,Austria,0.0365,0.1188,0.0264,0.035,0.0131
 2012,Belgium,0.0435,0.0828,0.0774,0.0407,0.018
@@ -78,7 +78,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2012,Switzerland,0.0917,0.0328,0.0421,0.1834,0.0291
 2012,United Kingdom,0.0533,0.072,0.1288,0.0024,0.0308
 2012,United States,0.1148,0.0321,0.2491,0.0274,0.0177
-2013,"DAC Countries, Total",0.0764,0.0576,0.122,0.0263,0.029
+2013,DAC countries,0.0764,0.0576,0.122,0.0263,0.029
 2013,Australia,0.0568,0.0836,0.1016,0.0631,0.0243
 2013,Austria,0.0368,0.1041,0.0255,0.0359,0.0152
 2013,Belgium,0.0654,0.0512,0.0775,0.0494,0.0239
@@ -108,7 +108,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2013,Switzerland,0.0988,0.0339,0.0403,0.1204,0.031
 2013,United Kingdom,0.0676,0.0735,0.1481,0.0021,0.0356
 2013,United States,0.1381,0.0284,0.2553,0.028,0.0205
-2014,"DAC Countries, Total",0.0905,0.0575,0.1201,0.0355,0.0297
+2014,DAC countries,0.0905,0.0575,0.1201,0.0355,0.0297
 2014,Australia,0.0628,0.11,0.0995,,0.0235
 2014,Austria,0.0405,0.1038,0.0279,0.0609,0.0114
 2014,Belgium,0.0519,0.047,0.0786,0.0545,0.0189
@@ -141,7 +141,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2014,Switzerland,0.0999,0.0371,0.0526,0.1161,0.0317
 2014,United Kingdom,0.0847,0.0677,0.1247,0.0083,0.0355
 2014,United States,0.1577,0.0318,0.2492,0.033,0.0237
-2015,"DAC Countries, Total",0.0939,0.0543,0.1029,0.0717,0.0274
+2015,DAC countries,0.0939,0.0543,0.1029,0.0717,0.0274
 2015,Australia,0.0721,0.0925,0.0877,,0.0114
 2015,Austria,0.0367,0.0912,0.0202,0.238,0.0184
 2015,Belgium,0.0816,0.043,0.0745,0.0854,0.0183
@@ -175,7 +175,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2015,Switzerland,0.1063,0.038,0.0465,0.1172,0.026
 2015,United Kingdom,0.097,0.0556,0.0992,0.0158,0.0299
 2015,United States,0.177,0.0319,0.2401,0.0388,0.0271
-2016,"DAC Countries, Total",0.092,0.0555,0.1036,0.0858,0.026
+2016,DAC countries,0.092,0.0555,0.1036,0.0858,0.026
 2016,Australia,0.0466,0.0603,0.0806,,0.0075
 2016,Austria,0.0398,0.0814,0.0198,0.2638,0.0121
 2016,Belgium,0.1112,0.0423,0.0616,0.1202,0.0223
@@ -209,7 +209,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2016,Switzerland,0.0905,0.0386,0.0423,0.1606,0.0276
 2016,United Kingdom,0.0909,0.0685,0.0912,0.0232,0.0269
 2016,United States,0.1576,0.0412,0.2592,0.0476,0.0255
-2017,"DAC Countries, Total",0.1027,0.0542,0.1079,0.073,0.0256
+2017,DAC countries,0.1027,0.0542,0.1079,0.073,0.0256
 2017,Australia,0.0676,0.0607,0.069,,0.013
 2017,Austria,0.0622,0.1078,0.0246,0.0816,0.0155
 2017,Belgium,0.093,0.053,0.0671,0.1029,0.0278
@@ -243,7 +243,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2017,Switzerland,0.0983,0.0454,0.0541,0.0859,0.0256
 2017,United Kingdom,0.0939,0.0517,0.1107,0.0201,0.0235
 2017,United States,0.1814,0.043,0.2675,0.0368,0.0222
-2018,"DAC Countries, Total",0.101,0.0587,0.1069,0.0541,0.0242
+2018,DAC countries,0.101,0.0587,0.1069,0.0541,0.0242
 2018,Australia,0.0597,0.0655,0.0944,,0.0111
 2018,Austria,0.0482,0.1146,0.0235,0.0344,0.0106
 2018,Belgium,0.0904,0.0559,0.0609,0.0742,0.0309
@@ -277,7 +277,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2018,Switzerland,0.0985,0.0474,0.0533,0.076,0.0247
 2018,United Kingdom,0.0894,0.052,0.1115,0.0188,0.0242
 2018,United States,0.1921,0.0457,0.2663,0.0428,0.0179
-2019,"DAC Countries, Total",0.109,0.0605,0.0962,0.0504,0.0235
+2019,DAC countries,0.109,0.0605,0.0962,0.0504,0.0235
 2019,Australia,0.0763,0.0572,0.0879,,0.0116
 2019,Austria,0.0539,0.1046,0.0227,0.0155,0.0184
 2019,Belgium,0.0896,0.0567,0.0583,0.0429,0.0232
@@ -311,7 +311,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2019,Switzerland,0.1002,0.0456,0.0527,0.0744,0.0172
 2019,United Kingdom,0.1104,0.0526,0.1153,0.0245,0.0231
 2019,United States,0.2282,0.0406,0.2169,0.0524,0.0162
-2020,"DAC Countries, Total",0.1028,0.055,0.1167,0.0411,0.0216
+2020,DAC countries,0.1028,0.055,0.1167,0.0411,0.0216
 2020,Australia,0.0813,0.0489,0.139,,0.0112
 2020,Austria,0.0618,0.1022,0.0217,0.015,0.0131
 2020,Belgium,0.0901,0.0521,0.0584,0.0386,0.0207
@@ -345,7 +345,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2020,Switzerland,0.1472,0.0433,0.079,0.0735,0.0156
 2020,United Kingdom,0.0966,0.0377,0.1214,0.0311,0.0174
 2020,United States,0.2179,0.0344,0.254,0.0366,0.0114
-2021,"DAC Countries, Total",0.112,0.0488,0.144,0.0538,0.021
+2021,DAC countries,0.112,0.0488,0.144,0.0538,0.021
 2021,Australia,0.0956,0.0556,0.2098,,0.0134
 2021,Austria,0.0885,0.1034,0.0419,0.0281,0.0131
 2021,Belgium,0.0904,0.0495,0.0666,0.065,0.0219
@@ -379,7 +379,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2021,Switzerland,0.0926,0.0437,0.1169,0.0782,0.0119
 2021,United Kingdom,0.0668,0.0369,0.1125,0.0644,0.0189
 2021,United States,0.2244,0.0241,0.2565,0.0841,0.0101
-2022,"DAC Countries, Total",0.1077,0.0436,0.125,0.1165,0.0171
+2022,DAC countries,0.1077,0.0436,0.125,0.1165,0.0171
 2022,Australia,0.1288,0.0657,0.1592,0.0,0.0103
 2022,Austria,0.0938,0.0872,0.0375,0.1442,0.0121
 2022,Belgium,0.0972,0.0489,0.0646,0.0802,0.0172
@@ -413,7 +413,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2022,Switzerland,0.1081,0.0382,0.0522,0.2364,0.012
 2022,United Kingdom,0.0883,0.0276,0.1012,0.2347,0.0266
 2022,United States,0.1868,0.02,0.2443,0.1127,0.0083
-2023,"DAC Countries, Total",0.1061,0.0427,0.0793,0.1081,0.0206
+2023,DAC countries,0.1061,0.0427,0.0793,0.1081,0.0206
 2023,Australia,0.1112,0.0551,0.1211,0.0,0.0165
 2023,Austria,0.0824,0.0971,0.0281,0.0942,0.0169
 2023,Belgium,0.1042,0.0492,0.062,0.0842,0.0167
@@ -447,7 +447,7 @@ year,name,Humanitarian,Education,Health,Refugees in Donor Countries,Environment 
 2023,Switzerland,0.1126,0.0367,0.0498,0.2351,0.0117
 2023,United Kingdom,0.0527,0.0255,0.1077,0.1985,0.0244
 2023,United States,0.2158,0.0255,0.1356,0.0977,0.0143
-2024,"DAC Countries, Total",0.1029,0.046,0.0963,0.0976,0.0257
+2024,DAC countries,0.1029,0.046,0.0963,0.0976,0.0257
 2024,Australia,0.0913,0.0386,0.1113,0.0,0.0112
 2024,Austria,0.0942,0.12,0.0238,0.0359,0.0215
 2024,Belgium,0.0845,0.046,0.0542,0.0927,0.0189

--- a/topic_page/oda_gni_sm.csv
+++ b/topic_page/oda_gni_sm.csv
@@ -1,2 +1,2 @@
-first_line,oda_gni,second_line,distance,centre
+Period,ODA/GNI,Subtitle,Gap to 0.7%,Centre
 As of 2025,0.002563,Additional required to get to 0.7%,301630.3,

--- a/topic_page/oda_key_numbers.json
+++ b/topic_page/oda_key_numbers.json
@@ -5,7 +5,7 @@
     "oda_gni": "0.26%",
     "oda_gni_distance": "302 billion",
     "aid_to_africa": "59.0 billion",
-    "aid_to_africa_share": "26.8%",
+    "aid_to_africa_share": "\"26.8%\"",
     "aid_to_incomes": {
         "High income": {
             "value": "0.8",
@@ -29,7 +29,7 @@
         }
     },
     "aid_to_health": "27.6 billion",
-    "aid_to_health_share": "9.6%",
+    "aid_to_health_share": "\"9.6%\"",
     "aid_to_humanitarian": "29.5 billion",
-    "aid_to_humanitarian_share": "10.3%"
+    "aid_to_humanitarian_share": "\"10.3%\""
 }

--- a/topic_page/sm_total_oda_csv
+++ b/topic_page/sm_total_oda_csv
@@ -1,2 +1,2 @@
-name,first_line,value,second_line,pct_change,centre
+Donor,Period,Total ODA,Subtitle,Annual change,Centre
 DAC countries,As of 2025,174262320000.0,real change from 2024,-23.1,-2.31


### PR DESCRIPTION
Standardise column names and fix percentage string formatting across topic page CSVs
  
  - Rename all output columns to title-case (`Year`, `Donor`, `Recipient`, etc.) for consistency across all topic page CSVs (`sm_total_oda, oda_gni_sm`, `aid_to_africa_ts`, `aid_to_health_ts`, `aid_to_humanitarian_ts`, `aid_to_income_latest`, `key_sector_shares`).
  - Wrap percentage share values in literal quote characters (e.g. `"26.8%"`) so Flourish treats them as strings rather than auto-detecting them as numbers and applying currency formatting.
  - Rename `"DAC Countries, Total"` → `"DAC countries"`.
