### PR TITLE
Feature/sectors pct donor

### DIFF
--- a/src/data/scripts/sectors_view.py
+++ b/src/data/scripts/sectors_view.py
@@ -15,8 +15,9 @@ from src.data.analysis_tools.transformations import (
     add_donor_names,
     add_recipient_names,
     widen_currency_price,
+    add_share_of_donors_total_oda,
 )
-from src.data.config import PATHS, SECTORS_TIME, logger
+from src.data.config import PATHS, SECTORS_TIME, DONOR_GROUPS, logger
 from src.data.analysis_tools.helper_functions import (
     set_cache_dir,
     get_dac_ids,
@@ -178,6 +179,27 @@ def combined_sectors():
 
     with open(PATHS.TOOLS / "sectors.json", "w") as f:
         json.dump(sector_mapping_filtered, f, indent=2)
+
+    # Add donor perspective share (share of donor's total ODA to developing countries)
+    sectors = add_share_of_donors_total_oda(sectors)
+
+    # Add recipient perspective share (share of ODA received by recipient from all donors).
+    # Computed from individual donor codes only — aggregate group codes (20_000–20_005)
+    # are excluded from the denominator to prevent double-counting and to include EU
+    # Institutions (918), which is absent from the "All bilateral donors" (20_000) group.
+    aggregate_codes = set(DONOR_GROUPS.values())
+    total_received = (
+        sectors.loc[~sectors["donor_code"].isin(aggregate_codes)]
+        .groupby(["year", "recipient_code"], dropna=False, observed=True)["value_usd_current"]
+        .sum()
+        .reset_index()
+        .rename(columns={"value_usd_current": "total_oda"})
+    )
+    sectors = sectors.merge(total_received, on=["year", "recipient_code"], how="left")
+    sectors["pct_total_recipient"] = (
+        sectors["value_usd_current"] / sectors["total_oda"]
+    ).round(6)
+    sectors = sectors.drop(columns=["total_oda"])
 
     # Convert values to units (integers) for better compression
     # NOTE: Frontend queries must divide value_* columns by 1e6 to get millions

--- a/src/js/sectorsQueries.js
+++ b/src/js/sectorsQueries.js
@@ -273,7 +273,9 @@ async function runSectorsQuery(db, {
                         : "indicator_name AS indicator_label,"
                     }
                     SUM(${valueColumn}) / 1e6 AS converted_value,
-                    SUM(value_usd_current) / 1e6 AS original_value
+                    SUM(value_usd_current) / 1e6 AS original_value,
+                    SUM(pct_total_donor) AS pct_total_donor,
+                    SUM(pct_total_recipient) AS pct_total_recipient
                 FROM ${parquetClause}
                 WHERE
                     donor_code = ${donor}
@@ -306,7 +308,9 @@ async function runSectorsQuery(db, {
         indicator: row.indicator_label,
         converted_value: row.converted_value ?? null,
         original_value: row.original_value ?? null,
-        indicator_total_original: row.indicator_original_value ?? null
+        indicator_total_original: row.indicator_original_value ?? null,
+        pct_total_donor: row.pct_total_donor ?? null,
+        pct_total_recipient: row.pct_total_recipient ?? null
     }));
 }
 
@@ -456,6 +460,8 @@ function buildTableBase(rows, {
                 original_value: row.original_value ?? null,
                 sector_total: sectorTotalsByYear.get(row.year) ?? null,
                 indicator_total: row.indicator_total_original ?? null,
+                pct_total_donor: row.pct_total_donor ?? null,
+                pct_total_recipient: row.pct_total_recipient ?? null,
                 currency,
                 prices,
                 indicatorUnitLabel,
@@ -467,7 +473,7 @@ function buildTableBase(rows, {
         .map(({__order, ...rest}) => rest);
 }
 
-function valueForUnit({unit, convertedValue, originalValue, sectorTotal, indicatorTotal}) {
+function valueForUnit({unit, convertedValue, originalValue, sectorTotal, indicatorTotal, pctTotalDonor, pctTotalRecipient}) {
     switch (unit) {
         case "value":
             return convertedValue ?? null;
@@ -475,6 +481,10 @@ function valueForUnit({unit, convertedValue, originalValue, sectorTotal, indicat
             return ratioAsPct(originalValue, sectorTotal);
         case "pct_total":
             return ratioAsPct(originalValue, indicatorTotal);
+        case "pct_total_donor":
+            return pctTotalDonor != null ? pctTotalDonor * 100 : null;
+        case "pct_total_recipient":
+            return pctTotalRecipient != null ? pctTotalRecipient * 100 : null;
         default:
             return convertedValue ?? null;
     }
@@ -491,6 +501,14 @@ function tableUnitLabel(unit, currency, prices, selectedSector, indicatorUnitLab
 
     if (unit === "pct_total") {
         return `% of ${indicatorUnitLabel}`;
+    }
+
+    if (unit === "pct_total_donor") {
+        return "% of total ODA provided";
+    }
+
+    if (unit === "pct_total_recipient") {
+        return "% of total ODA received";
     }
 
     return `${currency} ${prices} million`;
@@ -557,7 +575,9 @@ export function transformTableData(baseData, unit, breakdown) {
                 convertedValue: row.converted_value,
                 originalValue: row.original_value,
                 sectorTotal: row.sector_total,
-                indicatorTotal: row.indicator_total
+                indicatorTotal: row.indicator_total,
+                pctTotalDonor: row.pct_total_donor,
+                pctTotalRecipient: row.pct_total_recipient
             }),
             unit: unitLabel,
             source: row.source
@@ -575,11 +595,15 @@ export function transformTableData(baseData, unit, breakdown) {
             indicator: row.indicator,
             convertedValue: 0,
             originalValue: 0,
-            indicatorTotal: row.indicator_total
+            indicatorTotal: row.indicator_total,
+            pctTotalDonor: 0,
+            pctTotalRecipient: 0
         };
         entry.convertedValue += row.converted_value ?? 0;
         entry.originalValue += row.original_value ?? 0;
         entry.indicatorTotal = row.indicator_total ?? entry.indicatorTotal;
+        entry.pctTotalDonor += row.pct_total_donor ?? 0;
+        entry.pctTotalRecipient += row.pct_total_recipient ?? 0;
         aggregatedByYear.set(row.year, entry);
     }
 
@@ -596,7 +620,9 @@ export function transformTableData(baseData, unit, breakdown) {
                 convertedValue: entry.convertedValue,
                 originalValue: entry.originalValue,
                 sectorTotal: entry.originalValue,
-                indicatorTotal: entry.indicatorTotal
+                indicatorTotal: entry.indicatorTotal,
+                pctTotalDonor: entry.pctTotalDonor,
+                pctTotalRecipient: entry.pctTotalRecipient
             }),
             unit: unitLabel,
             source: baseData[0].source

--- a/src/sectors.md
+++ b/src/sectors.md
@@ -242,6 +242,8 @@ function App() {
             {label: getCurrencyLabel(currency, {currencyLong: true, currencyOnly: true}), value: "value"},
             {label: `% of ${sector} ODA`, value: "pct_sector", disabled: breakdownIsDisabled || !effectiveBreakdown},
             {label: `% of ${indicatorLabel} ODA`, value: "pct_total"},
+            {label: "% of provided aid", value: "pct_total_donor"},
+            {label: "% of received aid", value: "pct_total_recipient"},
         ]
     }, [currency, indicator, sector, breakdownIsDisabled, effectiveBreakdown])
 
@@ -288,6 +290,8 @@ function App() {
     const tableNote = React.useMemo(() => {
         if (unit === "value") return `ODA values in ${pricesNote} ${currencyLabel}.`
         if (unit === "pct_sector") return `ODA values as a share of ${sector} ODA received by ${recipientName} from ${donorName}.`
+        if (unit === "pct_total_donor") return `ODA values as a share of all aid provided by ${donorName} to developing countries.`
+        if (unit === "pct_total_recipient") return `ODA values as a share of all aid received by ${recipientName} from bilateral donors.`
         return `ODA values as a share of total aid received by ${recipientName} from ${donorName}.`
     }, [unit, currencyLabel, sector, recipientName, donorName])
 


### PR DESCRIPTION
### Add donor and recipient perspective share units to sectors table
  
  - Adds `pct_total_donor` and `pct_total_recipient` columns to the sectors parquet. Donor share = sector ODA as % of donor's total ODA to developing countries; recipient share = sector ODA as % of total ODA received by the recipient from all bilateral donors (including EU Institutions, which is absent from the DAC "All bilateral donors" aggregate and required an inline denominator to avoid values exceeding 100%).
  - Threads both columns through `sectorsQueries.js` (SQL, table base, unit computation) and exposes them as "% of provided aid" and "% of received aid" in the sectors table unit dropdown.
